### PR TITLE
fix(provider): revert version to older provider

### DIFF
--- a/manifests/providers/msq-provider.yaml
+++ b/manifests/providers/msq-provider.yaml
@@ -3,6 +3,6 @@ kind: Provider
 metadata:
   name: message-queue-provider
 spec:
-  package: deploy-releases-hyperspace-docker.common.cdn.repositories.cloud.sap/crossplane/provider-message-queue:1.0.0-20230109084715
+  package: deploy-releases-hyperspace-docker.common.cdn.repositories.cloud.sap/crossplane/provider-message-queue:1.0.0-20221208090704
   packagePullSecrets:
    - name: artifactory-readers

--- a/manifests/resources/msq-provider-config.yaml
+++ b/manifests/resources/msq-provider-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: pubsub.messagequeue.sap.crossplane.io/v1alpha1
+apiVersion: messagequeue.sap.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: message-provider-config

--- a/manifests/resources/msq-provider-config.yaml
+++ b/manifests/resources/msq-provider-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: messagequeue.btp.orchestrate.cloud.sap/v1alpha1
+apiVersion: pubsub.messagequeue.sap.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: message-provider-config

--- a/manifests/resources/queue.yaml
+++ b/manifests/resources/queue.yaml
@@ -1,0 +1,16 @@
+apiVersion: pubsub.messagequeue.sap.crossplane.io/v1alpha1
+kind: Queue
+metadata:
+  name: example
+spec:
+  forProvider:
+    configuration:
+      maxMessageSizeInBytes: 4200000
+      maxRedeliveryCount: 3
+      accessType: "EXCLUSIVE"
+    topics:
+      - "topgun-3"
+      - "topgun-4"
+      - "topgun-5"
+  providerConfigRef:
+    name: default

--- a/manifests/resources/queue.yaml
+++ b/manifests/resources/queue.yaml
@@ -13,4 +13,4 @@ spec:
       - "topgun-4"
       - "topgun-5"
   providerConfigRef:
-    name: default
+    name: message-provider-config


### PR DESCRIPTION
The newest version of the message queue provider is not stable, reverting to the old version for demo.